### PR TITLE
g-a: use actions/setup-go to setup the environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
+      with:
+        go-version-file: 'go.mod'
+    - run: go version
     
     - name: Install dependencies
       run: make dependencies


### PR DESCRIPTION
Having this explicit is always a good idea, but particularly needed when, by default, MacOS env's come with go 1.17, and we depend on a more recent version.